### PR TITLE
Add create_case tool and fix update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A Model Context Protocol (MCP) server that interfaces with ServiceNow, allowing 
 
 #### Basic Tools
 - `create_incident`: Create a new incident
+- `create_case`: Create a new case in the `sn_customerservice_case` table
 - `update_incident`: Update an existing incident
 - `search_records`: Search for records using text query
 - `get_record`: Get a specific record by sys_id

--- a/mcp_server_servicenow/nlp.py
+++ b/mcp_server_servicenow/nlp.py
@@ -115,10 +115,11 @@ class NLPProcessor:
         # Check for state changes
         if re.search(r'\b(working on|in progress|assign)\b', command, re.IGNORECASE):
             updates["state"] = 2  # In Progress
+        elif re.search(r'\b(close|closed)\b', command, re.IGNORECASE):
+            # Explicit close should override any resolve keywords
+            updates["state"] = 7  # Closed
         elif re.search(r'\b(resolve|resolved|fix|fixed)\b', command, re.IGNORECASE):
             updates["state"] = 6  # Resolved
-        elif re.search(r'\b(close|closed)\b', command, re.IGNORECASE):
-            updates["state"] = 7  # Closed
         
         # Extract comments or work notes
         comment_match = re.search(r'(?:saying|comment|note|with comment|with note)(?:s|)\s*:?\s*(.+?)(?:$|\.(?:\s|$))', command, re.IGNORECASE)


### PR DESCRIPTION
## Summary
- fix natural language update command parsing to prioritize closing
- add a `CaseCreate` model and `create_case` tool for creating entries in `sn_customerservice_case`
- register the new tool
- document the new `create_case` capability in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68643494927883338fd4eb8caa3ef6e3